### PR TITLE
Php unit compat is made in wordpress's bootstrap

### DIFF
--- a/src/WPPPB/Loader.php
+++ b/src/WPPPB/Loader.php
@@ -75,9 +75,6 @@ class WPPPB_Loader {
 	 * @since 0.1.0
 	 */
 	protected function __construct() {
-
-		$this->phpunit_compat();
-
 		if ( $this->should_install_plugins() ) {
 			$this->hook_up_installer();
 		}


### PR DESCRIPTION
Loading this file will fail in the latest wp version (5.1 ) because they moved it in https://develop.svn.wordpress.org/tags/5.1/tests/phpunit/includes/phpunit6/compat.php

So you should let wordpress bootstraper do this (which they do on the first line of https://develop.svn.wordpress.org/tags/5.1/tests/phpunit/includes/bootstrap.php)