### PR TITLE
Display the data of the message when a plugin activation fails

### DIFF
--- a/src/WPPPB/Loader.php
+++ b/src/WPPPB/Loader.php
@@ -228,12 +228,20 @@ class WPPPB_Loader {
 
 		if ( class_exists( 'PHPUnit\Runner\Version' ) ) {
 
-			/**
-			 * Compatibility with PHPUnit 6+.
-			 *
-			 * @since 0.3.2
-			 */
-			require_once $this->get_wp_tests_dir() . '/includes/phpunit6-compat.php';
+			if ( file_exists( $this->get_wp_tests_dir() . '/includes/phpunit6-compat.php' ) ) {
+				/**
+				 * Compatibility with PHPUnit 6+.
+				 *
+				 * @since 0.3.2
+				 */
+				require_once $this->get_wp_tests_dir() . '/includes/phpunit6-compat.php';
+			}
+			if ( file_exists( $this->get_wp_tests_dir() . '/includes/phpunit6/compat.php' ) ) {
+				/**
+				 * Compatibility with PHPUnit 6+ for WP 5.1.
+				 */
+				require_once $this->get_wp_tests_dir() . '/includes/phpunit6/compat.php';
+			}
 
 			class_alias(
 				'PHPUnit\Framework\Constraint\Constraint'

--- a/src/bin/install-plugins.php
+++ b/src/bin/install-plugins.php
@@ -63,8 +63,12 @@ foreach ( $plugins_info as $plugin => $info ) {
 		
 		echo "Error: Plugin activation failed for {$plugin}:" . PHP_EOL;
 		
-		foreach ( $result->get_error_messages() as $message ) {
-			echo "- {$message}" . PHP_EOL;
+		foreach ($result->get_error_codes() as $code) {
+			echo "- " . $result->get_error_message( $code ) . PHP_EOL;
+			$data = $result->get_error_data( $code );
+			if ( ! empty( $data ) && is_string( $data ) ) {
+				echo "Data: " . $data;
+			}
 		}
 		
 		exit( 1 );


### PR DESCRIPTION
The wordpress error message for a plugin activation is always the same:
return new WP_Error('unexpected_output', __('The plugin generated unexpected output.'), $output);

So the error message is not really helpfull
As such displaying the output there will help debuging


Also fix compatibility with WP4.8- and WP 5.1+ because the required file do not exist 